### PR TITLE
Propose solution for issue #3: Naming conflict with SwiftUI’s SliderTick

### DIFF
--- a/Sources/DiscreteSlider/Components/Tick/AnySliderTick.swift
+++ b/Sources/DiscreteSlider/Components/Tick/AnySliderTick.swift
@@ -25,14 +25,14 @@
 import SwiftUI
 
 /// A type that represents any slider tick that can be used by ``DiscreteSlider``.
-public struct AnySliderTick: SliderTick {
+public struct AnySliderTick: DiscreteSliderTick {
 
     public var width: CGFloat
     public var height: CGFloat
 
     private let _makeBody: () -> AnyView
 
-    public init<Tick: SliderTick>(tick: Tick) {
+    public init<Tick: DiscreteSliderTick>(tick: Tick) {
         self.width = tick.width
         self.height = tick.height
         self._makeBody = tick.makeBodyErased

--- a/Sources/DiscreteSlider/Components/Tick/DiscreteSliderTick.swift
+++ b/Sources/DiscreteSlider/Components/Tick/DiscreteSliderTick.swift
@@ -25,7 +25,7 @@
 import SwiftUI
 
 /// Tick marks are placed along a track and represent predetermined values that the user can move the slider to.
-public protocol SliderTick {
+public protocol DiscreteSliderTick {
     associatedtype Tick: View
 
     /// The width of the tick view.
@@ -41,7 +41,7 @@ public protocol SliderTick {
     func makeBody() -> Self.Tick
 }
 
-extension SliderTick {
+extension DiscreteSliderTick {
 
     /// Function used to type-erase view that represents slider's tick.
     /// - Returns: Type-erased tick view.

--- a/Sources/DiscreteSlider/Styles/Default/DefaultSliderTick.swift
+++ b/Sources/DiscreteSlider/Styles/Default/DefaultSliderTick.swift
@@ -24,7 +24,7 @@
 
 import SwiftUI
 
-public struct DefaultSliderTick: SliderTick {
+public struct DefaultSliderTick: DiscreteSliderTick {
     public let width: CGFloat
     public let height: CGFloat
 

--- a/Sources/DiscreteSlider/Styles/Prominent/ProminentSliderTick.swift
+++ b/Sources/DiscreteSlider/Styles/Prominent/ProminentSliderTick.swift
@@ -23,7 +23,7 @@
 
 import SwiftUI
 
-public struct ProminentSliderTick: SliderTick {
+public struct ProminentSliderTick: DiscreteSliderTick {
 
     public let width: CGFloat
     public let height: CGFloat

--- a/Sources/DiscreteSlider/View/DiscreteSlider.swift
+++ b/Sources/DiscreteSlider/View/DiscreteSlider.swift
@@ -57,7 +57,7 @@ public struct DiscreteSlider<Option: Equatable>: View {
     ///   - handle: Customized slider's handle.
     ///   - label: Customized slider's label.
     ///   - selectedItem: Binding to the property that will store the selected item.
-    public init<Track: SliderTrack, Tick: SliderTick, Handle: SliderHandle, Label: SliderLabel>(
+    public init<Track: SliderTrack, Tick: DiscreteSliderTick, Handle: SliderHandle, Label: SliderLabel>(
         options: [Option],
         track: Track,
         tick: Tick,
@@ -88,7 +88,7 @@ public struct DiscreteSlider<Option: Equatable>: View {
     ///   - handle: Customized slider's handle.
     ///   - animated: Enable animation of the slider.
     ///   - selectedItem: Binding to the property that will store the selected item.
-    public init<Track: SliderTrack, Tick: SliderTick, Handle: SliderHandle>(
+    public init<Track: SliderTrack, Tick: DiscreteSliderTick, Handle: SliderHandle>(
         options: [Option],
         track: Track = DefaultSliderTrack(),
         tick: Tick? = DefaultSliderTick(),

--- a/Sources/DiscreteSlider/View/SliderControl.swift
+++ b/Sources/DiscreteSlider/View/SliderControl.swift
@@ -63,7 +63,7 @@ struct SliderControl<Option: Equatable>: View {
     ///   - tick: Customized slider's tick.
     ///   - handle: Customized slider's handle.
     ///   - selectedItem: Binding to the property that will store the selected item.
-    public init<Track: SliderTrack, Tick: SliderTick, Handle: SliderHandle>(
+    public init<Track: SliderTrack, Tick: DiscreteSliderTick, Handle: SliderHandle>(
         options: [Option],
         track: Track = DefaultSliderTrack(),
         tick: Tick? = DefaultSliderTick(),


### PR DESCRIPTION
This a proposal for the Naming conflict with SwiftUI’s SliderTick struct from iOS 26 #3
